### PR TITLE
terraform: reduce boot instances and remove volumes

### DIFF
--- a/hosts_boot.tf
+++ b/hosts_boot.tf
@@ -16,11 +16,6 @@ module "boot" {
   ac_type = local.ws["ac_type"] /* Alibaba Cloud */
   gc_type = local.ws["gc_type"] /* Google Cloud */
 
-  /* data volumes */
-  ac_data_vol_size = local.ws["data_vol_size"]
-  do_data_vol_size = local.ws["data_vol_size"]
-  gc_data_vol_size = local.ws["data_vol_size"]
-
   /* firewall */
   open_udp_ports = [
     "9000", /* discovery v5 */

--- a/hosts_store.tf
+++ b/hosts_store.tf
@@ -16,11 +16,6 @@ module "store" {
   ac_type = local.ws["ac_type"] /* Alibaba Cloud */
   gc_type = local.ws["gc_type"] /* Google Cloud */
 
-  /* data volumes */
-  ac_data_vol_size = local.ws["data_vol_size"]
-  do_data_vol_size = local.ws["data_vol_size"]
-  gc_data_vol_size = local.ws["data_vol_size"]
-
   /* firewall */
   open_udp_ports = [
     "9000", /* discovery v5 */

--- a/workspaces.tf
+++ b/workspaces.tf
@@ -11,14 +11,12 @@ locals {
     defaults = {
       /* Default settings for all fleets/workspaces. */
 
-      boot_hosts_count = 2
+      boot_hosts_count = 1
       store_hosts_count = 2
 
       do_type = "s-1vcpu-2gb" /* DigitalOcean */
       ac_type = "ecs.t5-lc1m2.small" /* Alibaba Cloud */
       gc_type = "g1-small" /* Google Cloud */
-
-      data_vol_size = 40
     }
 
     test = {


### PR DESCRIPTION
We only need 1 boot instance for testing.
Data is stored in PostgreSQL on separate nodes.