### PR TITLE
boot: turn trace logs for boot-01 nodes

### DIFF
--- a/ansible/group_vars/boot.yml
+++ b/ansible/group_vars/boot.yml
@@ -3,8 +3,7 @@
 # Tag dependent on fleet: test
 nim_waku_cont_tag: 'deploy-shards-{{ stage }}'
 nim_waku_cont_name: 'nim-waku-boot'
-# TODO: switch for traces foe 1 node in host_vars
-nim_waku_log_level: 'debug'
+nim_waku_log_level: "{{ 'trace' if ansible_hostname == 'boot-01' else 'debug' }}"
 nim_waku_protocols_enabled: ['relay', 'filter', 'lightpush', 'peer-exchange']
 nim_waku_disc_v5_enabled: true
 nim_waku_dns4_domain_name: '{{ dns_entry }}'

--- a/ansible/group_vars/store.yml
+++ b/ansible/group_vars/store.yml
@@ -3,7 +3,6 @@
 # Tag dependent on fleet: test
 nim_waku_cont_tag: 'deploy-shards-{{ stage }}'
 nim_waku_cont_name: 'nim-waku-store'
-# TODO: switch for traces foe 1 node in host_vars
 nim_waku_log_level: 'debug'
 nim_waku_protocols_enabled: ['relay', 'store']
 nim_waku_disc_v5_enabled: true


### PR DESCRIPTION
> Configuration for status.sharding.bootstrap
>    1 node in this fleet should preferably be set up with trace-level message logs, in order
> to facilitate future end-to-end message tracing and debugging

- https://github.com/status-im/infra-shards/issues/2